### PR TITLE
fix: type errors and vitest config for typescript

### DIFF
--- a/src/components/MediaItem.test.tsx
+++ b/src/components/MediaItem.test.tsx
@@ -6,7 +6,7 @@ describe("MediaItem tests", () => {
     const requiredProps = {
       media: {
         id: "8c1c",
-        type: "book",
+        type: "book" as const,
         title: "Book 1",
         author: "Author 1",
         yearPublished: 2019,

--- a/src/components/MediaList.tsx
+++ b/src/components/MediaList.tsx
@@ -19,8 +19,7 @@ export function MediaList({
 }: MediaListProps) {
   // accept searchTerm and filterBy (mapping, movie|book -> type)
   const updatedList = useMemo(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    let filterFn = (m: AvailableMediaType) => true;
+    let filterFn: (m: AvailableMediaType) => boolean = () => true;
     if (filterBy === "book" || filterBy === "movie") {
       filterFn = ({ type }) => type === filterBy;
     } else {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
-  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
- fix type errors so running `pnpm run client:build` would succeed.
- incorrect Vitest config (`compilerOptions.types` should be placed in app's tsconfig.json)